### PR TITLE
Kills AdminWho and AdminHelp

### DIFF
--- a/code/datums/keybinding/client.dm
+++ b/code/datums/keybinding/client.dm
@@ -2,7 +2,7 @@
 	category = CATEGORY_CLIENT
 	weight = WEIGHT_HIGHEST
 
-
+/*
 /datum/keybinding/client/admin_help
 	hotkey_keys = list("F1")
 	name = "admin_help"
@@ -13,7 +13,7 @@
 	user.get_adminhelp()
 	return TRUE
 
-/*
+
 /datum/keybinding/client/screenshot
 	hotkey_keys = list("F2")
 	name = "screenshot"

--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -132,10 +132,10 @@
 /datum/world_topic/adminwho
 	keyword = "adminwho"
 	require_comms_key = TRUE
-
+/*
 /datum/world_topic/adminwho/Run(list/input)
 	return ircadminwho()
-
+*/
 /datum/world_topic/status
 	keyword = "status"
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -32,7 +32,7 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/delete_player_book,
 	/client/proc/amend_player_book,
 	/client/proc/pull_book_file_names,
-	/client/proc/adminwho,
+	// /client/proc/adminwho, //NO MORE ADMINWHO
 	/client/proc/admin_spread_effect,
 	// RATWOOD MODULAR START
 	/client/proc/bunker_bypass,

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -69,10 +69,10 @@
 	name = "adminwho"
 	help_text = "Lists administrators currently on the server"
 	admin_only = TRUE
-
+/* NO MORE ADMINWHO, Uncomment if you want it again!
 /datum/tgs_chat_command/adminwho/Run(datum/tgs_chat_user/sender, params)
 	return ircadminwho()
-
+*/
 GLOBAL_LIST(round_end_notifiees)
 
 /datum/tgs_chat_command/endnotify

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -89,7 +89,7 @@ GLOBAL_PROTECT(href_token)
 	if ((C = owner) || (C = GLOB.directory[target]))
 		disassociate()
 		C.verbs += /client/proc/readmin
-		C.verbs += /client/proc/adminwho
+		//C.verbs += /client/proc/adminwho 
 
 /datum/admins/proc/associate(client/C)
 	if(IsAdminAdvancedProcCall())

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -502,17 +502,19 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 
 // Used for methods where input via arg doesn't work
 /client/proc/get_adminhelp()
-	var/msg = input(src, "Please describe your problem concisely and an admin will help as soon as they're able.", "Adminhelp contents") as text
-	adminhelp(msg)
+	// Replace the input prompt and call with the direct alert
+	var/discord_msg = ("Please Go to the Discord and File your problem in the #Adminhelp Channel!")
+	alert(src, discord_msg, "Adminhelp Information")
 
-/client/verb/adminhelp(msg as text)
+/client/verb/adminhelp()
 	set category = "Admin"
 	set name = "Adminhelp"
 
-	if(GLOB.say_disabled)	//This is here to try to identify lag problems
-		to_chat(usr, span_danger("Speech is currently admin-disabled."))
-		return
-
+	// Replace the entire verb logic with the alert
+	var/discord_msg = ("Please Go to the Discord and File your problem in the #Adminhelp Channel!")
+	alert(src, discord_msg, "Adminhelp Information")
+	return // Prevent any further processing of the original adminhelp logic
+	/*
 	//handle muting and automuting
 	if(prefs.muted & MUTE_ADMINHELP)
 		to_chat(src, span_danger("Error: Admin-PM: You cannot send adminhelps (Muted)."))
@@ -539,7 +541,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			current_ticket.Close()
 
 	new /datum/admin_help(msg, src, FALSE)
-
+*/
 //
 // LOGGING
 //
@@ -617,7 +619,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	for(var/I in servers)
 		world.Export("[servers[I]]?[list2params(message)]")
 
-
+/*
 /proc/ircadminwho()
 	var/list/message = list("Admins: ")
 	var/list/admin_keys = list()
@@ -632,7 +634,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 			message += "[admin]"
 
 	return jointext(message, "")
-
+*/
 /proc/keywords_lookup(msg,irc)
 
 	//This is a list of words which are ignored by the parser when comparing message contents for names. MUST BE IN LOWER CASE!

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -247,7 +247,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		connecting_admin = TRUE
 	else if(GLOB.deadmins[ckey])
 		verbs += /client/proc/readmin
-		verbs += /client/proc/adminwho
+		//verbs += /client/proc/adminwho 
 		connecting_admin = TRUE
 	if(CONFIG_GET(flag/autoadmin))
 		if(!GLOB.admin_datums[ckey])

--- a/code/modules/client/verbs/who.dm
+++ b/code/modules/client/verbs/who.dm
@@ -94,7 +94,7 @@
 	if(holder)
 		msg += "<br><b>Whitelisted players:</b> [wled]"
 	to_chat(src, msg)
-
+/* No more adminwho!, uncomment if you want it again, there's also a pair of verbs += /client/proc/adminwho which this needs in holder2dm and client_procs.dm
 /client/proc/adminwho()
 	set category = "Admin"
 	set name = "Adminwho"
@@ -131,4 +131,4 @@
 				msg += "\t[C] is a [C.holder.rank]\n"
 		msg += span_info("Adminhelps are also sent to IRC. If no admins are available in game adminhelp anyways and an admin on IRC will see it and respond.")
 	to_chat(src, msg)
-
+*/


### PR DESCRIPTION
Various Things And Removals To kill adminhelp and adminwho

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removes Adminwho and Adminhelp, the former by removing it entirely as it was still showing up when removing the verb in admin_verbs, it removes the latter by simply making the button say that you should go to the discord

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Big man told me to do it

![MergeMyPr](https://github.com/user-attachments/assets/9ec2e7cd-b63e-42a8-9ec1-eed851be4df7)
