### PR TITLE
The big PQ lessening

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/inquisitor.dm
@@ -17,7 +17,7 @@
 	display_order = JDO_INQUISITOR
 	advclass_cat_rolls = list(CTAG_INQUISITOR = 20)
 	give_bank_account = 30
-	min_pq = 10
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sister.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/sister.dm
@@ -1,6 +1,6 @@
 /datum/advclass/sister
 	name =  "Nun"
-	tutorial = "A Nun of the Valorian Silent Sisterhood, your whispers alone strikes fear into witches and warlocks"
+	tutorial = "A Nun of the Valorian Silent Sisterhood, your whispers alone strikes fear into witches and warlocks."
 	allowed_sexes = list(FEMALE)
 	allowed_races = RACES_RESPECTED_UP
 	outfit = /datum/outfit/job/roguetown/sister

--- a/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/bandit.dm
@@ -16,7 +16,7 @@
 
 	display_order = JDO_BANDIT
 	announce_latejoin = FALSE
-	min_pq = 3
+	min_pq = -3
 	max_pq = null
 	round_contrib_points = 5
 

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -11,7 +11,7 @@
 	outfit_female = null
 	display_order = JDO_WRETCH
 	show_in_credits = FALSE
-	min_pq = 20
+	min_pq = 10
 	max_pq = null
 
 	advclass_cat_rolls = list(CTAG_WRETCH = 20)

--- a/code/modules/jobs/job_types/roguetown/church/acolyte.dm
+++ b/code/modules/jobs/job_types/roguetown/church/acolyte.dm
@@ -14,7 +14,7 @@
 
 	display_order = JDO_ACOLYTE
 	give_bank_account = TRUE
-	min_pq = 1 //A step above Churchling, should funnel new players to the churchling role to learn miracles at a more sedate pace
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/church/priest.dm
+++ b/code/modules/jobs/job_types/roguetown/church/priest.dm
@@ -18,7 +18,7 @@
 
 	display_order = JDO_PRIEST
 	give_bank_account = 115
-	min_pq = 5 // You should know the basics of things if you're going to lead the town's entire religious sector
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 4
 

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -10,7 +10,7 @@
 	allowed_races = RACES_SHUNNED_UP
 	allowed_patrons = ALL_DIVINE_PATRONS
 	outfit = /datum/outfit/job/roguetown/templar
-	min_pq = 3 //Deus vult, but only according to the proper escalation rules
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 2
 	total_positions = 3

--- a/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/councillor.dm
@@ -14,7 +14,7 @@
 
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 1 //Probably a bad idea to have a complete newbie advising the monarch
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 2
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/courtier/jester.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/jester.dm
@@ -17,7 +17,7 @@
 	outfit = /datum/outfit/job/roguetown/jester
 	display_order = JDO_JESTER
 	give_bank_account = TRUE
-	min_pq = -4 //silly jesters are funny so low PQ requirement
+	min_pq = -5
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/courtier/magician.dm
+++ b/code/modules/jobs/job_types/roguetown/courtier/magician.dm
@@ -25,7 +25,7 @@
 	outfit = /datum/outfit/job/roguetown/magician
 	whitelist_req = TRUE
 	give_bank_account = 120
-	min_pq = 5
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 2
 	cmode_music = 'sound/music/combat_bandit_mage.ogg'

--- a/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/sergeant.dm
@@ -16,7 +16,7 @@
 	outfit = /datum/outfit/job/roguetown/sergeant
 
 	give_bank_account = 50
-	min_pq = 6
+	min_pq = 3
 	max_pq = null
 	cmode_music = 'sound/music/combat_guard2.ogg'
 

--- a/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/townguard.dm
@@ -17,7 +17,7 @@
 	advclass_cat_rolls = list(CTAG_WATCH = 20)
 
 	give_bank_account = 16
-	min_pq = 1 //Introductory guard role, but still requires knowledge of escalation.
+	min_pq = 1
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/veteran.dm
@@ -22,7 +22,7 @@
 	display_order = JDO_VET
 	whitelist_req = TRUE
 	give_bank_account = 35
-	min_pq = 5 //Should...probably actually be a veteran of at least a few weeks before trying to teach others
+	min_pq = 3
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
+++ b/code/modules/jobs/job_types/roguetown/garrison/villagechief.dm
@@ -13,7 +13,7 @@
 	whitelist_req = TRUE
 	outfit = /datum/outfit/job/roguetown/woodsman
 	display_order = JDO_CHIEF
-	min_pq = 2 //mentor role, not a high PQ requirement but not zero
+	min_pq = 3
 	max_pq = null
 	give_bank_account = 16
 	round_contrib_points = 3

--- a/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/mercenary.dm
@@ -10,7 +10,7 @@
 	tutorial = "Blood stains your hands and the coins you hold. You are a sell-sword, a mercenary, a contractor of war. Where you come from, what you are, who you serve.. none of it matters. What matters is that the mammon flows to your pocket."
 	display_order = JDO_MERCENARY
 	selection_color = JCOLOR_MERCENARY
-	min_pq = 2		//Will be handled by classes if PQ limiting is needed. --But Until then, learn escalation, mercs.
+	min_pq = 2
 	max_pq = null
 	round_contrib_points = 1
 	outfit = null	//Handled by classes

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -25,7 +25,7 @@
 
 	give_bank_account = 26
 	noble_income = 16
-	min_pq = 9
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_knight.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/hand.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/hand.dm
@@ -15,7 +15,7 @@
 	whitelist_req = TRUE
 	give_bank_account = 44
 	noble_income = 22
-	min_pq = 9 //The second most powerful person in the realm...
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/hand2.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -23,7 +23,7 @@
 
 	give_bank_account = 22
 	noble_income = 10
-	min_pq = 8
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 2
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lady.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lady.dm
@@ -22,7 +22,7 @@
 	display_order = JDO_LADY
 	give_bank_account = 50
 	noble_income = 22
-	min_pq = 5
+	min_pq = 0
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/nobility/lord.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/lord.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(lord_titles)
 	display_order = JDO_LORD
 	tutorial = "At one point you were merely a vassal to the Ruby Throne, given special status and overseen by the Empress herself. However since her death there has been almost no communication outside of the city. You have had to take increasing amounts of autocratic power in order to sustain your port, so much so that many see you as effectively a monarch in your own right. And many want to take this from you, or use it to their advantage- keep your family alive and your power secure, and Lyndvhar may live to see another dae."
 	whitelist_req = FALSE
-	min_pq = 10
+	min_pq = 5
 	max_pq = null
 	round_contrib_points = 4
 	give_bank_account = 1000

--- a/code/modules/jobs/job_types/roguetown/nobility/marshal.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/marshal.dm
@@ -16,7 +16,7 @@
 
 	give_bank_account = 40
 	noble_income = 20
-	min_pq = 8
+	min_pq = 4
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_guard.ogg'

--- a/code/modules/jobs/job_types/roguetown/nobility/steward.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/steward.dm
@@ -13,7 +13,7 @@
 	outfit = /datum/outfit/job/roguetown/steward
 	give_bank_account = 22
 	noble_income = 16
-	min_pq = 3 //Please don't give the vault keys to somebody that's going to lock themselves in on accident
+	min_pq = 3
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
+++ b/code/modules/jobs/job_types/roguetown/peasants/knavewench.dm
@@ -8,7 +8,7 @@
 	spawn_positions = 4
 
 	allowed_races = RACES_SHUNNED_UP
-	tutorial = "You have a simple role at the tavern; please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
+	tutorial = "You have a simple role at the tavern: please. You wait tables and help guests, clean the rooms, grow and brew more drink, and assist in the kitchens as need be. Bring a smile to the masses--and those cheapsake townsfolk and adventures might just give you an extra coin...assuming you've not already pilfered their pouch while they're in a drunken stupor off your latest brew."
 
 	outfit = /datum/outfit/job/roguetown/knavewench
 	display_order = JDO_KNAVEWENCH

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -20,7 +20,7 @@
 	outfit = /datum/outfit/job/roguetown/archivist
 	display_order = JDO_ARCHIVIST
 	give_bank_account = 15
-	min_pq = 1 // Please do not read smut while brewing bottle bombs. It upsets the maids when they have to scrape archivists off the ceiling.
+	min_pq = 1
 	max_pq = null
 	round_contrib_points = 3
 

--- a/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/nightmaster.dm
@@ -12,7 +12,7 @@
 	outfit = /datum/outfit/job/roguetown/niteman
 	display_order = JDO_NITEMASTER
 	give_bank_account = 20
-	min_pq = 1 //No drugs until you finish the tutorial, Jimmy!
+	min_pq = -4
 	max_pq = null
 	bypass_lastclass = TRUE
 	round_contrib_points = 3

--- a/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/prince.dm
@@ -22,7 +22,7 @@
 	display_order = JDO_PRINCE
 	give_bank_account = 30
 	noble_income = 20
-	min_pq = 1
+	min_pq = -1
 	max_pq = null
 	round_contrib_points = 3
 	cmode_music = 'sound/music/combat_noble.ogg'

--- a/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
+++ b/code/modules/jobs/job_types/roguetown/youngfolk/squire.dm
@@ -22,7 +22,7 @@
 	outfit = /datum/outfit/job/roguetown/squire
 	display_order = JDO_SQUIRE
 	give_bank_account = TRUE
-	min_pq = -5 //squires aren't great but they can do some damage
+	min_pq = -5
 	max_pq = null
 	round_contrib_points = 2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Some of these were really stupid and needed changed. PlayerQuality itself should not be such a heavy measure in to how we stop people from playing jobs beyond as punishment measures. Anybody and their mother can just farm PQ, so it shouldn't be used as such a measurement.

This server is not going to be doing things the Vanderlin way (making PQ measurements insanely high) nor any other way beyond what is presented here.

So here's how this is going to go-
Important jobs are going to be 5PQ. That goes for the Viscount, blah blah.
Jobs below this are going to be 4.
And the others below are 3, 2, 1, 0, etc. There's no reason for it to be as restrictive as it was.

## Why It's Good For The Game

Makes me happier and brings in line with our rules, regulations, etc.
