### PR TITLE
Lecherine/Leech Repellent

### DIFF
--- a/code/datums/gods/patrons/inhumen_pantheon.dm
+++ b/code/datums/gods/patrons/inhumen_pantheon.dm
@@ -14,7 +14,7 @@
 	domain = "Archdaemon of Advancement, Hubris, Ambition, and Power"
 	desc = "The Archdaemon ZIZO was the first to be born from the sins of mortalkind. She represents the aspects of unbridled ambition, and the lust for more power. It was her forces that first breached through the Hells and into the realm of Beowricke proper, bringing destruction as she began to carve out a realm for herself. She and her cultists crafted the TIEFLING from her lesser daemons as well as mortals. "
 	worshippers = "Necromancers, Warlocks, and the Undead"
-	mob_traits = list(TRAIT_CABAL)
+	mob_traits = list(TRAIT_CABAL, TRAIT_LEECHIMMUNE)
 	t1 = /obj/effect/proc_holder/spell/invoked/projectile/profane/miracle
 	t2 = /obj/effect/proc_holder/spell/invoked/raise_lesser_undead/miracle
 	t3 = /obj/effect/proc_holder/spell/invoked/rituos/miracle

--- a/code/modules/cargo/packsrogue/tools.dm
+++ b/code/modules/cargo/packsrogue/tools.dm
@@ -99,6 +99,11 @@
 					/obj/item/natural/worms/leech,
 				)
 
+/datum/supply_pack/rogue/tools/leechrepellent
+	name = "Leech Repellent"
+	cost = 25
+	contains = list(/obj/item/reagent_containers/glass/bottle/rogue/leechrepellent)
+
 /datum/supply_pack/rogue/tools/prarml
 	name = "Prosthetic Wood Arm (L)"
 	cost = 40

--- a/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
+++ b/code/modules/roguetown/roguecrafting/alchemy/reagents.dm
@@ -190,6 +190,42 @@
 	..()
 	. = 1
 
+/datum/reagent/medicine/leechrepellent
+	name = "Lecherine"
+	description = ""
+	reagent_state = LIQUID
+	color = "#385c38"
+	taste_description = "acrid vomit"
+	overdose_threshold = 15
+	metabolization_rate = 0.02 * REAGENTS_METABOLISM
+
+/datum/reagent/medicine/leechrepellent/on_mob_metabolize(mob/living/carbon/human/C)
+	..()
+	if(HAS_TRAIT(C, TRAIT_LEECHIMMUNE))
+		volume = 0
+		to_chat(C, "<span class='necrosis'>My body's humors are already as vile as they could be.</span>")
+		return
+	else
+		var/con = max(1, (C.STACON - 8))
+		to_chat(C, "<span class='infection'>Your stomach churns.</span>")
+		C.add_nausea(240-(con*40))
+		ADD_TRAIT(C, TRAIT_LEECHIMMUNE, type)
+
+/datum/reagent/medicine/leechrepellent/on_mob_end_metabolize(mob/living/carbon/human/C)
+	REMOVE_TRAIT(C, TRAIT_LEECHIMMUNE, type)
+	..()
+
+/datum/reagent/medicine/leechrepellent/overdose_start(mob/living/carbon/human/C)
+	to_chat(C, "<span class='necrosisbig'>Repulsive!</span>")
+	C.add_nausea(100)
+
+/datum/reagent/medicine/leechrepellent/overdose_process(mob/living/carbon/human/C)
+	if(C.nausea < 100)
+		C.add_nausea(100)
+		volume -= 3
+	..()
+	. = 1
+
 //Buff potions
 /datum/reagent/buff
 	description = ""

--- a/code/modules/roguetown/roguejobs/alchemist/container.dm
+++ b/code/modules/roguetown/roguejobs/alchemist/container.dm
@@ -14,6 +14,9 @@
 /obj/item/reagent_containers/glass/bottle/rogue/water
 	list_reagents = list(/datum/reagent/water = 48)
 
+/obj/item/reagent_containers/glass/bottle/rogue/leechrepellent
+	list_reagents = list(/datum/reagent/medicine/leechrepellent = 48)
+
 //vanderlin potion stuff//
 /obj/item/reagent_containers/glass/bottle/rogue/strongmanapot
 	list_reagents = list(/datum/reagent/medicine/strongmana = 45)

--- a/goon/browserassets/css/browserOutput.css
+++ b/goon/browserassets/css/browserOutput.css
@@ -467,6 +467,7 @@ h1.alert, h2.alert	{color: #c9c1ba;font-family: Pterra, TrueType;}
 .artery					{color: #9B5455;}
 .infection				{color: #77c72b;}
 .necrosis				{color: #558d20;}
+.necrosisbig				{color: #558d20;	font-weight: bold;	font-size: 150%;}
 .bone					{color: #e3dac9;}
 .love_low					{color: #eac8de;	font-size: 75%;}
 .love_mid					{color: #e9a8d1;	font-size: 75%;}


### PR DESCRIPTION
## About The Pull Request
Adds a leech repellent potion to the Goldface. It is a vile concoction that makes your blood taste equally vile to any leeches who would dare feed on your blood. First drinking it causes you to vomit depending on your Constitution, and drinking too much makes you aggressively puke it all out.

Also adds the leech immune trait to Zizo worshippers by default, since they were the only Inhumen Worshippers without a bonus trait.

## Why It's Good For The Game
Adds a layer of preparation for swamp expeditions. Since these can only be acquired through the Merchant, it also encourages Adventurers to seek out his patronage in doing so.
