### PR TITLE
2 AM Combat Dev [TESTMERGE FIRST]

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1629,3 +1629,20 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars,list(
 		var/percentage = skill_level / SKILL_LEVEL_LEGENDARY // Turns it into a percentage
 		var/result = LERP(slowest, fastest, percentage)
 		return result SECONDS
+
+// How long an action (e.g. do_after) can takes IN SECONDS by using stat checks, from 5 to 16
+/proc/get_stat_delay(stat, fastest = 0.4, slowest = 6.4) 
+	if(stat <= 5) //can't divivde by zero
+		return slowest SECONDS
+	if(stat >= 16)
+		return fastest SECONDS
+	else
+		var/percentage = stat / 16 // Turns it into a percentage
+		var/result = LERP(slowest, fastest, percentage)
+		return result SECONDS
+
+/proc/get_unarmed_cd(stat, extra_cd = 0) //Thrown together to serve as a reusable stat-based clickcd for things like jumping and kicking.
+	var/cooldown = (22 - stat)
+	cooldown = clamp(cooldown, 8, 14)
+	cooldown += extra_cd 
+	return cooldown

--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -10,7 +10,7 @@
 		return
 	if(SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, over, usr) & COMPONENT_NO_MOUSEDROP)	//Whatever is receiving will verify themselves for adjacency.
 		return
-	if(!Adjacent(usr) || !over.Adjacent(usr))
+	if(!Adjacent(usr) || !over.Adjacent(usr) && !istype(over, /turf/closed))
 		return // should stop you from dragging through windows
 	var/list/L = params2list(params)
 	if (L["middle"])

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -22,6 +22,8 @@
 	var/chargedrain = 0 //how mcuh fatigue is removed every second when at max charge
 	var/releasedrain = 5 //drain when we go off, regardless
 	var/misscost = 0	//extra drain from missing only, ALSO APPLIED IF ENEMY DODGES
+	var/parrycost = 0 //Extra drain applied on defender after parrying this intent.
+	var/dodgecost = 0 //Extra drain applied on defender after dodging this intent.
 	var/tranged = 0
 	var/noaa = FALSE //turns off auto aiming, also turns off the 'swooshes'
 	var/warnie = ""
@@ -486,6 +488,9 @@
 			if(M.can_see_cone(user))
 				to_chat(M, span_green("[user] gives me a friendly wave."))
 	return
+
+/datum/intent/simple
+	unarmed = TRUE
 
 /datum/intent/simple/headbutt
 	name = "headbutt"

--- a/code/game/objects/items/rogueweapons/intents.dm
+++ b/code/game/objects/items/rogueweapons/intents.dm
@@ -489,9 +489,6 @@
 				to_chat(M, span_green("[user] gives me a friendly wave."))
 	return
 
-/datum/intent/simple
-	unarmed = TRUE
-
 /datum/intent/simple/headbutt
 	name = "headbutt"
 	icon_state = "instrike"

--- a/code/game/objects/items/rogueweapons/melee/axes.dm
+++ b/code/game/objects/items/rogueweapons/melee/axes.dm
@@ -242,7 +242,6 @@
 	force = 22
 	force_wielded = 28
 	desc = "A steel woodcutting axe. Performs much better than its iron counterpart."
-	force = 26
 	max_blade_int = 500
 	smeltresult = /obj/item/ingot/steel
 	wdefense = 3

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -23,8 +23,14 @@
 		if(L.mobility_flags & MOBILITY_MOVE)
 			wallpress(L)
 			return
+	else
+		if(isliving(O) && isliving(user) && get_dist(O, src) <= 1)
+			var/mob/living/L = user
+			if(L.mobility_flags & MOBILITY_MOVE)
+				wallpress(O, L)
+				return
 
-/turf/closed/proc/wallpress(mob/living/user)
+/turf/closed/proc/wallpress(mob/living/user, pushed = null)
 	if(user.wallpressed)
 		return
 	if(user.pixelshifted)
@@ -36,7 +42,10 @@
 		return
 	user.wallpressed = dir2wall
 	user.update_wallpress_slowdown()
-	user.visible_message(span_info("[user] leans against [src]."))
+	if(!pushed)
+		user.visible_message(span_info("[user] leans against [src]."))
+	else
+		user.visible_message(span_warning("[pushed] pushes [user] against [src]!"))
 	switch(dir2wall)
 		if(NORTH)
 			user.setDir(SOUTH)

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -82,8 +82,6 @@ GLOBAL_VAR(restart_counter)
 
 	load_nameban()
 
-	load_psychokiller()
-
 	load_crownlist()
 
 	load_bypassage()

--- a/code/modules/admin/blacklist.dm
+++ b/code/modules/admin/blacklist.dm
@@ -50,32 +50,6 @@ GLOBAL_PROTECT(nameban)
 
 #undef NAMEBANFILE
 
-
-#define PSYCHOFILE "[global.config.directory]/roguetown/psychokiller.txt"
-
-GLOBAL_LIST(psychokiller)
-GLOBAL_PROTECT(psychokiller)
-
-/proc/load_psychokiller()
-	GLOB.psychokiller = list()
-	for(var/line in world.file2list(PSYCHOFILE))
-		if(!line)
-			continue
-		if(findtextEx(line,"#",1,2))
-			continue
-		GLOB.psychokiller += ckey(line)
-
-	if(!GLOB.psychokiller.len)
-		GLOB.psychokiller = null
-
-/proc/check_psychokiller(ckey)
-	if(!GLOB.psychokiller)
-		return FALSE
-	. = (ckey in GLOB.psychokiller)
-
-#undef PSYCHOFILE
-
-
 #define BYPASSAGEFILE "[global.config.directory]/roguetown/bypassage.txt"
 
 GLOBAL_LIST(bypassage)

--- a/code/modules/clothing/rogueclothes/neck.dm
+++ b/code/modules/clothing/rogueclothes/neck.dm
@@ -207,6 +207,7 @@
 	body_parts_covered = NECK|MOUTH|NOSE
 	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_SMASH, BCLASS_TWIST, BCLASS_BITE)
 	blocksound = PLATEHIT
+	armor_class = ARMOR_CLASS_HEAVY //On neck slot, only checked to prevent choke grabs.
 
 /obj/item/clothing/neck/roguetown/gorget
 	name = "gorget"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/atgervi.dm
@@ -111,6 +111,9 @@
 	desc = "Thick fur pants made to endure the coldest winds, offering a share of protection from fang and claw of beast or men alike."
 	icon_state = "atgervi_pants"
 	item_state = "atgervi_pants"
+	armor = list("blunt" = 55, "slash" = 70, "stab" = 55, "fire" = 0, "acid" = 0)
+	prevent_crits = list(BCLASS_CUT, BCLASS_CHOP, BCLASS_BLUNT, BCLASS_BITE, BCLASS_TWIST)
+	max_integrity = 300
 	
 /obj/item/clothing/gloves/roguetown/angle/atgervi
 	name = "fur-lined leather gloves"
@@ -152,6 +155,9 @@
 	desc = "A pair of strong leather boots, designed to endure battle and the chill of the north both."
 	icon_state = "atgervi_boots"
 	item_state = "atgervi_boots"
+	max_integrity = 200
+	armor = list("blunt" = 55, "slash" = 55, "stab" = 50, "piercing" = 35, "fire" = 0, "acid" = 0)
+	prevent_crits = list(BCLASS_BLUNT, BCLASS_SMASH, BCLASS_CUT, BCLASS_BITE)
 
 /obj/item/rogueweapon/shield/atgervi
 	name = "kite shield"
@@ -177,8 +183,9 @@
 				return list("shrink" = 0.7,"sx" = -17,"sy" = -15,"nx" = -15,"ny" = -15,"wx" = -12,"wy" = -15,"ex" = -18,"ey" = -15,"nturn" = 0,"sturn" = 0,"wturn" = 180,"eturn" = 0,"nflip" = 8,"sflip" = 0,"wflip" = 1,"eflip" = 0,"northabove" = 1,"southabove" = 0,"eastabove" = 0,"westabove" = 0)
 
 /obj/item/rogueweapon/stoneaxe/woodcut/steel/atgervi
-	name = "Bearded Axe"
+	name = "bearded axe"
 	desc = "A large axe easily wielded in one hand or two, With a large hooked axehead to tearing into flesh and armor and ripping it away brutally."
+	force = 26
 	icon_state = "atgervi_axe"
 	item_state = "atgervi_axe"
 	lefthand_file = 'icons/mob/inhands/weapons/rogue_lefthand.dmi'

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -134,8 +134,9 @@
 	var/hurt = TRUE
 	if(hit_atom.density && isturf(hit_atom))
 		if(hurt)
-			Paralyze(20)
 			take_bodypart_damage(10,check_armor = TRUE)
+			visible_message(span_danger("[src] [pick("slams", "crashes", "flies")] against [hit_atom]!"), \
+				span_userdanger("I am sent [pick("flying", "crashing")] against [hit_atom]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -136,7 +136,7 @@
 		if(hurt)
 			take_bodypart_damage(10,check_armor = TRUE)
 			visible_message(span_danger("[src] [pick("slams", "crashes", "flies")] against [hit_atom]!"), \
-				span_userdanger("I am sent [pick("flying", "crashing")] against [hit_atom]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
+				span_userdanger("I am sent [pick("flying", "crashing")] against [hit_atom]!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE)
 	if(iscarbon(hit_atom) && hit_atom != src)
 		var/mob/living/carbon/victim = hit_atom
 		if(victim.movement_type & FLYING)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -115,6 +115,7 @@
 
 	var/used_str = STASTR
 
+	var/obj/G = get_item_by_slot(SLOT_GLOVES)
 	if(domhand)
 		used_str = get_str_arms(used_hand)
 
@@ -124,11 +125,40 @@
 	if(used_str <= 9)
 		damage = max(damage - (damage * ((10 - used_str) * 0.1)), 1)
 
+	if(istype(G, /obj/item/clothing/gloves/roguetown/plate/atgervi))
+		damage = (damage * 1.35)
+	else 
+		if(istype(G, /obj/item/clothing/gloves/roguetown/plate))
+			damage = (damage * 1.20)
+	if(istype(G, /obj/item/clothing/gloves/roguetown/chain))
+		damage = (damage * 1.15)
+	if(istype(G, /obj/item/clothing/gloves/roguetown/leather))
+		damage = (damage * 1.10) 
+
 	if(mind)
 		if(mind.has_antag_datum(/datum/antagonist/werewolf))
 			return 30
 
 	return damage
+
+/mob/living/carbon/human/get_punch_ap()
+	var/armor_penetration = 10
+
+	var/used_str = STASTR
+
+	var/obj/G = get_item_by_slot(SLOT_GLOVES)
+	if(domhand)
+		used_str = get_str_arms(used_hand)
+
+	if(istype(G, /obj/item/clothing/gloves/roguetown/chain))
+		armor_penetration += 5
+	if(istype(G, /obj/item/clothing/gloves/roguetown/plate))
+		armor_penetration += 10
+	
+	if(used_str >= 11)
+		armor_penetration = max(armor_penetration + (armor_penetration * ((used_str - 10) * 0.3)), 1)
+	
+	return armor_penetration
 
 /mob/living/carbon/human/proc/is_noble()
 	var/noble = FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1136,6 +1136,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			return
 
 		var/damage = user.get_punch_dmg()
+		var/punch_ap = user.get_punch_ap()
 
 /*		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
 		if(user.dna.species.punchdamagelow)
@@ -1163,7 +1164,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!target.lying_attack_check(user))
 			return 0
 
-		var/armor_block = target.run_armor_check(selzone, "blunt", blade_dulling = user.used_intent.blade_class, damage = damage)
+		var/armor_block = target.run_armor_check(selzone, "blunt", armor_penetration = punch_ap, blade_dulling = user.used_intent.blade_class, damage = damage)
 
 		target.lastattacker = user.real_name
 		if(target.mind)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -198,6 +198,8 @@
 						emote("painmoan")
 						mob_timers["painstun"] = world.time + 20 SECONDS
 						add_stress(/datum/stressevent/painmax)
+						if(!(mobility_flags & MOBILITY_STAND))
+							to_chat(src, span_boldwarning("I can't keep going for much longer!"))
 
 /mob/living/carbon/proc/handle_roguebreath()
 	return

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -160,33 +160,44 @@
 	if(!stat)
 		var/painpercent = get_complex_pain() / pain_threshold
 		painpercent = painpercent * 100
-
 		if(world.time > mob_timers["painstun"])
-			mob_timers["painstun"] = world.time + 100
-			var/probby = 40 - (STAEND * 2)
-			probby = max(probby, 10)
-			if(lying || IsKnockdown())
-				if(prob(3) && (painpercent >= 80) )
+			mob_timers["painstun"] = world.time + 10 SECONDS
+			switch(painpercent)
+				if(-INFINITY to 99)
+					return
+				if(100 to 149)
+					Immobilize(5)
+					set_blurriness(5)
+					rogfat_add(10)
+					visible_message(span_warning("[src] winces in pain!"))
+					mob_timers["painstun"] = world.time + 15 SECONDS
+					add_stress(/datum/stressevent/painmax)
+				if(150 to 199)
+					Immobilize(10)
+					set_blurriness(8)
+					rogfat_add(20)
+					visible_message(span_warning("<b>[src] winces in pain!</b>"))
 					emote("painmoan")
-			else
-				if(painpercent >= 100)
-					if(prob(probby) && !HAS_TRAIT(src, TRAIT_NOPAINSTUN))
+					mob_timers["painstun"] = world.time + 20 SECONDS
+					add_stress(/datum/stressevent/painmax)
+				if(200 to INFINITY) //Game over.
+					var/paincritchance = (55 - (STACON + STAEND))
+					if(prob(paincritchance))
 						Immobilize(10)
+						set_blurriness(8)
 						emote("painscream")
 						stuttering += 5
 						addtimer(CALLBACK(src, PROC_REF(Stun), 110), 10)
 						addtimer(CALLBACK(src, PROC_REF(Knockdown), 110), 10)
-						mob_timers["painstun"] = world.time + 160
+						mob_timers["painstun"] = world.time + 25 SECONDS
 					else
+						Immobilize(10)
+						set_blurriness(8)
+						rogfat_add(20)
+						visible_message(span_warning("<b>[src] winces in pain!</b>"))
 						emote("painmoan")
-						stuttering += 5
-				else
-					if(painpercent >= 80)
-						if(probby)
-							emote("painmoan")
-
-		if(painpercent >= 100)
-			add_stress(/datum/stressevent/painmax)
+						mob_timers["painstun"] = world.time + 20 SECONDS
+						add_stress(/datum/stressevent/painmax)
 
 /mob/living/carbon/proc/handle_roguebreath()
 	return

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -98,7 +98,7 @@
 						if(fallingas > 15)
 							Sleeping(300)
 				else
-					rogstam_add(sleepy_mod * 10)
+					rogstam_add(sleepy_mod * 20)
 			// Resting on the ground (not sleeping or with eyes closed and about to fall asleep)
 			else if(!(mobility_flags & MOBILITY_STAND))
 				if(eyesclosed)
@@ -121,11 +121,11 @@
 						if(fallingas > 25)
 							Sleeping(300)
 				else
-					rogstam_add(10)
+					rogstam_add(20)
 			else if(fallingas)
 				fallingas = 0
 		else if(HAS_TRAIT(src, TRAIT_NOSLEEP) && !(mobility_flags & MOBILITY_STAND))
-			rogstam_add(5)
+			rogstam_add(10)
 
 		handle_brain_damage()
 
@@ -158,9 +158,6 @@
 	if(HAS_TRAIT(src, TRAIT_NOPAIN))
 		return
 	if(!stat)
-		var/pain_threshold = STAEND * 10
-		if(has_flaw(/datum/charflaw/masochist)) // Masochists handle pain better by about 1 endurance point
-			pain_threshold += 10
 		var/painpercent = get_complex_pain() / pain_threshold
 		painpercent = painpercent * 100
 
@@ -241,7 +238,7 @@
 	for(var/obj/item/bodypart/limb as anything in bodyparts)
 		if(limb.status == BODYPART_ROBOTIC || limb.skeletonized)
 			continue
-		var/bodypart_pain = ((limb.brute_dam + limb.burn_dam) / limb.max_damage) * 100
+		var/bodypart_pain = ((limb.brute_dam + (limb.burn_dam/2)) / limb.max_damage) * 100
 		for(var/datum/wound/wound as anything in limb.wounds)
 			bodypart_pain += wound.woundpain
 		bodypart_pain = min(bodypart_pain, 100) //tops out at 100 per limb

--- a/code/modules/mob/living/grabbing.dm
+++ b/code/modules/mob/living/grabbing.dm
@@ -186,13 +186,21 @@
 				if(iscarbon(M) && M != user)
 					user.rogfat_add(rand(1,3))
 					var/mob/living/carbon/C = M
-					if(get_location_accessible(C, BODY_ZONE_PRECISE_NECK))
-						if(prob(25))
+					var/chokedamage = clamp(((user.STASTR - C.STACON)*8), user.STASTR, 50)
+					if(get_location_unarmored(C, BODY_ZONE_PRECISE_NECK, 2)) //Heavy neck armor prevents this altogether.
+						if(prob(chokedamage))
 							C.emote("choke")
-						C.adjustOxyLoss(user.STASTR)
-					C.visible_message(span_danger("[user] [pick("chokes", "strangles")] [C]!"), \
-									span_userdanger("[user] [pick("chokes", "strangles")] me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
-					to_chat(user, span_danger("I [pick("choke", "strangle")] [C]!"))
+						if(C.getOxyLoss() < 120) //This is to stop choking from speedrunning kills now that it can deal more damage.
+							C.adjustOxyLoss(chokedamage)
+						else
+							C.adjustOxyLoss(5)
+						C.visible_message(span_danger("[user] [pick("chokes", "strangles")] [C]!"), \
+										span_userdanger("[user] [pick("chokes", "strangles")] me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
+						to_chat(user, span_danger("I [pick("choke", "strangle")] [C]!"))
+					else
+						C.visible_message(span_danger("[user] uselessly attemmpts to [pick("choke", "strangle")] [C]!"), \
+										span_userdanger("[user] tries to [pick("choke", "strangle")] me!"), span_hear("I hear a sickening sound of pugilism!"), COMBAT_MESSAGE_RANGE, user)
+						to_chat(user, span_danger("I can't [pick("choke", "strangle")] [C] through their neckguard!"))
 		if(/datum/intent/grab/twist)
 			if(limb_grabbed && grab_state > 0) //this implies a carbon victim
 				if(iscarbon(M))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1749,7 +1749,7 @@
 
 ///Checks if the user is incapacitated or on cooldown.
 /mob/living/proc/can_look_up()
-	return !((next_move > world.time) || incapacitated(ignore_restraints = TRUE))
+	return !(incapacitated(ignore_restraints = TRUE))
 
 /**
  * look_up Changes the perspective of the mob to any openspace turf above the mob
@@ -1851,7 +1851,7 @@
 		return
 	if(!can_look_up())
 		return
-	changeNext_move(CLICK_CD_MELEE)
+	changeNext_move(CLICK_CD_RAPID)
 	if(m_intent != MOVE_INTENT_SNEAK)
 		visible_message(span_info("[src] looks up."))
 	var/turf/ceiling = get_step_multiz(src, UP)
@@ -1880,15 +1880,6 @@
 
 	if(T.can_see_sky())
 		do_time_change()
-
-	var/ttime = 10
-	if(STAPER > 5)
-		ttime = 10 - (STAPER - 5)
-		if(ttime < 0)
-			ttime = 0
-
-	if(!do_after(src, ttime, target = src))
-		return
 	reset_perspective(ceiling)
 	update_cone_show()
 //	RegisterSignal(src, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(stop_looking)) //We stop looking up if we move.

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -526,16 +526,13 @@
 
 		//------------Duel Wielding Checks------------
 		var/attacker_dualw
-		var/defender_dualw
 		var/extraattroll
-		var/extradefroll
 		var/mainhand = L.get_active_held_item()
 		var/offhand	= L.get_inactive_held_item()
 		//Duel Wielder defense disadvantage
 		if(mainhand && offhand)
 			if(HAS_TRAIT(src, TRAIT_DUALWIELDER) && istype(offhand, mainhand))
-				extradefroll = prob(prob2defend)
-				defender_dualw = TRUE
+				prob2defend -= 20
 
 		//dual-wielder attack advantage
 		var/obj/item/mainh = U.get_active_held_item()
@@ -554,15 +551,11 @@
 			to_chat(src, span_info("[text]"))
 
 		var/dodge_status = FALSE
-		if((defender_dualw && attacker_dualw) || (!defender_dualw && !attacker_dualw)) //They cancel each other out
-			if(prob(prob2defend))
-				dodge_status = TRUE
-		else if(attacker_dualw)
-			if(!prob(prob2defend) || !extraattroll)
+		if(prob(prob2defend))
+			dodge_status = TRUE
+		if(attacker_dualw)
+			if(!extraattroll)
 				dodge_status = FALSE
-		else if(defender_dualw)
-			if(prob(prob2defend) && extradefroll)
-				dodge_status = TRUE
 
 		if(!dodge_status)
 			return FALSE

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -545,7 +545,7 @@
 
 		if(client?.prefs.showrolls)
 			var/text = "Roll to dodge... [prob2defend]%"
-			if(defender_dualw)
+			if(attacker_dualw)
 				text += " Twice! Disadvantage!"
 			to_chat(src, span_info("[text]"))
 

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -220,7 +220,6 @@
 
 			//Dual Wielding
 			var/attacker_dualw
-			var/defender_dualw
 			var/extraattroll
 
 			//Dual Wielder defense disadvantage
@@ -237,7 +236,7 @@
 
 			if(src.client?.prefs.showrolls)
 				var/text = "Roll to parry... [prob2defend]%"
-				if((defender_dualw || attacker_dualw))
+				if(attacker_dualw)
 					text += " Twice! Disadvantage!"
 				to_chat(src, span_info("[text]"))
 			

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -193,8 +193,6 @@
 					prob2defend -= (attacker_skill * 20)
 					if(user.STASPD > src.STASPD)
 						prob2defend -= ((user.STASPD - src.STASPD)*10) //In line with D&D, unarmed attacks are finesseable.
-					if(user.STASTR > src.STASTR)
-						drained += ((user.STASTR - src.STASTR)*2.5) //Unarmed attacks also cost additional stamina to parry if the user is stronger, by default they cost 2 less to parry.
 
 
 			if(HAS_TRAIT(src, TRAIT_GUIDANCE))
@@ -212,7 +210,7 @@
 					var/mob/living/carbon/human/SH = H
 					var/sentinel = SH.calculate_sentinel_bonus()
 					prob2defend += sentinel
-			if(intenty.unarmed)
+			if(intenty.unarmed || istype(U, /mob/living/simple_animal))
 				prob2defend = clamp(prob2defend, 5, 95) //Parrying clumsy unarmed attacks is more consistent
 				drained -= 2
 			else
@@ -258,6 +256,10 @@
 				if(intenty.masteritem)
 					if(intenty.masteritem.wbalance < 0 && user.STASTR > src.STASTR) //enemy weapon is heavy, so get a bonus scaling on strdiff
 						drained = drained + ( intenty.masteritem.wbalance * ((user.STASTR - src.STASTR) * -5) )
+				else
+					if(intenty.unarmed)
+						if(user.STASTR > src.STASTR)
+							drained += ((user.STASTR - src.STASTR)*2.5) //Unarmed attacks also cost additional stamina to parry if the user is stronger, by default they cost 2 less to parry.
 			else
 				to_chat(src, span_warning("The enemy defeated my parry!"))
 				if(HAS_TRAIT(src, TRAIT_MAGEARMOR))

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -627,7 +627,7 @@
 						if(status.effectedstats["intelligence"] > 0)
 							fakeint -= status.effectedstats["intelligence"]
 		if(fakeint > 10)
-			var/bonus = round(((fakeint - 10) / 2)) * 10
+			var/bonus = ((fakeint - 10) / 2) * 10
 			if(bonus > 0)
 				if(HAS_TRAIT(src, TRAIT_HEAVYARMOR) || HAS_TRAIT(src, TRAIT_MEDIUMARMOR) || HAS_TRAIT(src, TRAIT_DODGEEXPERT) || HAS_TRAIT(src, TRAIT_CRITICAL_RESISTANCE))
 					bonus = clamp(bonus, 0, 25)

--- a/code/modules/mob/living/roguetownprocs.dm
+++ b/code/modules/mob/living/roguetownprocs.dm
@@ -600,6 +600,8 @@
 /mob/proc/get_punch_dmg()
 	return
 
+/mob/proc/get_punch_ap()
+	return
 
 /mob/proc/add_family_hud(antag_hud_type, antag_hud_name)
 	var/datum/atom_hud/antag/hud = GLOB.huds[antag_hud_type]

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -79,7 +79,7 @@
 				change_stat("intelligence", 2)
 		if(STAEND > 10)
 			pain_threshold = STAEND * 25
-			if(has_flaw(/datum/charflaw/masochist)) // Masochists handle pain better by about 1 endurance point
+			if(has_flaw(/datum/charflaw/masochist))
 				pain_threshold += 25
 		
 

--- a/code/modules/mob/living/stats.dm
+++ b/code/modules/mob/living/stats.dm
@@ -15,6 +15,7 @@
 	var/STAEND = 10
 	var/STASPD = 10
 	var/STALUC = 10
+	var/pain_threshold = 100
 	//buffers, the 'true' amount of each stat
 	var/BUFSTR = 0
 	var/BUFPER = 0
@@ -76,18 +77,11 @@
 				change_stat("perception", -1)
 				change_stat("constitution", -2)
 				change_stat("intelligence", 2)
-		if(key)
-			if(check_blacklist(ckey(key)))
-				change_stat("strength", -5)
-				change_stat("speed", -20)
-				change_stat("endurance", -2)
-				change_stat("constitution", -2)
-				change_stat("intelligence", -20)
-				change_stat("fortune", -20)
-			if(check_psychokiller(ckey(key)))
-				testing("foundpsych")
-				H.eye_color = "ff0000"
-				H.voice_color = "ff0000"
+		if(STAEND > 10)
+			pain_threshold = STAEND * 25
+			if(has_flaw(/datum/charflaw/masochist)) // Masochists handle pain better by about 1 endurance point
+				pain_threshold += 25
+		
 
 /mob/living/proc/change_stat(stat, amt, index)
 	if(!stat)

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -127,6 +127,15 @@
 				return FALSE
 	return TRUE
 
+/proc/get_location_unarmored(mob/victim, location = BODY_ZONE_CHEST, targetAC = 0) //0 checks for Light+, 1 for Medium+, 2 for Heavy.
+	if(iscarbon(victim))
+		var/mob/living/carbon/carbon_victim = victim 
+		for(var/obj/item/clothing/equipped_item in carbon_victim.get_equipped_items(include_pockets = FALSE))
+			if(zone2covered(location, equipped_item.body_parts_covered))
+				if(equipped_item.armor_class > targetAC)
+					return FALSE
+	return TRUE
+
 /proc/zone2covered(location, covered_locations)
 	switch(location)
 		if(BODY_ZONE_HEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
A couple of assorted changes to combat, as well as a bugfix.

- Unarmed attacks, such as grabs and punches, now have their parry/dodge chance capped at 95% instead of 90%. This is to represent the difficulty in hitting someone with your bare hands when otherwise hopelessly outmatched in melee. It also makes 'grab gambling', banking on the minimum 10% chance to land a grab, less powerful.
- All simplemob attacks count as being unarmed for the above change.
- Unarmed strikes can now benefit from having a higher speed than the opponent, reducing their parry/dodge chance, as well as from having higher strenght than the opponent, increasing their parry drain. This is the equivalent of these strikes having the properties of both swift and heavy weapons combined. Simplemobs do not benefit from this.
- Being prone now reduces dodge chance by 60% instead of 75%.
- The message for someone dodging your attack now changes if they have 90% or higher dodge chance, to provide feedback as to what is and isn't working.
- Fixed a bug that made choking people out do nothing if they had anything flagged as neck covering in their neck slot.
- Choking is now more powerful, dealing oxygen damage based on user's Strenght vs target's Constitution. At high discrepancies this is enough to knock someone out in two chokes.
- For now, bevors prevent choking altogether. Can be expanded down to gorgets later if it feels necessary.
- Dual-wielding now applies a flat -20% penalty on defense, rather than giving you disadvantage on the roll. This is intended as a buff. Needs testing, but should be fine (finding two identical weapons can be a hassle, one-handed weapons tend to have poor defenses, carrying them around is a hassle, lack of a free hand, opportunity cost of not using a twohander, etc.)
- Removes wallbanging (hardstun from being thrown into a wall). It now also displays a visible message when this happens, so you can know all the times this change has saved your ass. Yay!

## To-do

- I just realized I initialized vars for extra parry/dodge cost when parrying/dodging certain intents but forgot to actually implement them and then assign them to some intents to buff them. Intended mostly as another way to counter dodge for specific weapons, or to make heavier blows more taxing to parry.
- Re-add melee hit knockback under some reworked logic. Ideally mostly cosmetic, blunt attacks are strong enough as is.

## Why It's Good For The Game
Hopefully makes combat feel better. The NPC changes are aimed to make fighting NPCs a bit more forgiving, might bundle in a slight parry/dodge drain decrease if the attacker is a NPC.
