### PR TITLE
Gives barbarian Another weapon option on spawn

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/special.dm
+++ b/code/game/objects/items/rogueweapons/melee/special.dm
@@ -274,6 +274,7 @@
 	force = 20
 
 /obj/item/rogueweapon/knuckles // no actual sprite for this yet so its just the basis for the eora knuckles + for later futureproofing
+	slot_flags = ITEM_SLOT_HIP
 	name = "steel knuckles"
 	desc = "A mean looking pair of steel knuckles."
 	force = 15

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/combat/warrior.dm
@@ -120,12 +120,15 @@
 			ADD_TRAIT(H, TRAIT_NOPAINSTUN, TRAIT_GENERIC)
 			H.cmode_music = 'sound/music/combat_rhaenvalian.ogg'
 			H.set_blindness(0)
-			var/weapons = list("Katar","Axe","MY BARE HANDS!!!")
+			var/weapons = list("Katar","Steel Duster","Axe","MY BARE HANDS!!!")
 			var/weapon_choice = input("Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 			switch(weapon_choice)
 				if ("Katar")
 					H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
 					beltr = /obj/item/rogueweapon/katar
+				if ("Steel Duster")
+					H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 1, TRUE)
+					beltr = /obj/item/rogueweapon/knuckles
 				if("Axe")
 					H.mind.adjust_skillrank(/datum/skill/combat/axes, 1, TRUE)
 					beltr = /obj/item/rogueweapon/stoneaxe/boneaxe


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
adds steel dusters to the Barbarian's weapon loadout. 
also fixes a bug that stopped them from spawning in on the wretch berserker and barbarian.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another thing for barbarians to punch stuff with.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
