### PR TITLE
Eliminates being very faithful

### DIFF
--- a/modular_azurepeak/virtues/combat.dm
+++ b/modular_azurepeak/virtues/combat.dm
@@ -13,7 +13,7 @@
 			recipient.mind?.adjust_spellpoints(2)
 	else
 		recipient.mind?.adjust_spellpoints(2) // 2 extra spellpoints since you don't get any spell point from the skill anymore
-
+/*
 /datum/virtue/combat/devotee
 	name = "Devotee"
 	desc = "Though not officially of the Church, my relationship with my chosen Patron is strong enough to grant me the most minor of their blessings. I've also kept a psycross of my deity. Combat-oriented classes get a weaker version of this virtue."
@@ -75,6 +75,7 @@
 			recipient.mind?.special_items["Ravox Psycross"] =/obj/item/clothing/neck/roguetown/psicross/ravox
 		if(/datum/patron/divine/malum)
 			recipient.mind?.special_items["Malum Psycross"] = /obj/item/clothing/neck/roguetown/psicross/malum
+*/
 
 /datum/virtue/combat/duelist
 	name = "Duelist Apprentice"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Comments out Devotee from being able to be picked as a virtue, like Latent Arcyne.

## Why It's Good For The Game

Devotee has been used as a way to get free healing miracles. I thought it would be neat to have to show people with closer connections to the Pantheon, but it's not really being used as anything more than this. If anyone can come up with a more interesting form of Devotee, go ahead and do it- but this is how it's going to be dealt with for now.
