### PR TITLE
Goldface Contigency Change

### DIFF
--- a/code/modules/roguetown/roguemachine/merchant.dm
+++ b/code/modules/roguetown/roguemachine/merchant.dm
@@ -319,7 +319,7 @@
 
 	contents += "</center><BR>"
 
-	var/list/unlocked_cats = list("Apparel","Tools","Seeds","Luxury","Raw Materials")
+	var/list/unlocked_cats = list("Apparel","Tools","Seeds","Luxury","Raw Materials","Armor","Weapons","Consumable","Wardobre","Alcohols","Livestock") //Added the unlockable categories by default. Revert this or rework this later, its a lowpop contingency.
 	if(upgrade_flags & UPGRADE_ARMOR)
 		unlocked_cats+="Armor"
 	if(upgrade_flags & UPGRADE_WEAPONS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Unlocks all categories of goods on the Goldface by default. Meant to be reverted or reworked later.

## Why It's Good For The Game
The server hasn't yet reached a stable population and as consequence, merchant characters are very rare. Unlocking these categories, in this case, by default allows makes the Goldface more useful to the residents of the town and allows for more gimmicks.
