### PR TITLE
This adds deadite ambushes to serveral areas

### DIFF
--- a/code/game/area/roguetownareas.dm
+++ b/code/game/area/roguetownareas.dm
@@ -156,7 +156,8 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/turf/open/floor/rogue/grass)
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 30,
-				/mob/living/carbon/human/species/skeleton/npc/ambush = 50)
+				/mob/living/carbon/human/species/skeleton/npc/ambush = 50,
+				/mob/living/carbon/human/species/npc/deadite = 30)
 	first_time_text = "AZURE BASIN"
 	droning_sound = 'sound/music/area/field.ogg'
 	droning_sound_dusk = 'sound/music/area/septimus.ogg'
@@ -189,7 +190,8 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 	ambush_mobs = list(
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 40,
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 10,
-				/mob/living/carbon/human/species/goblin/npc/ambush = 30)
+				/mob/living/carbon/human/species/goblin/npc/ambush = 30,
+				/mob/living/carbon/human/species/npc/deadite = 10)
 	first_time_text = "THE AZURE GROVE"
 	converted_type = /area/rogue/indoors/shelter/woods
 
@@ -234,6 +236,7 @@ GLOBAL_LIST_INIT(roguetown_areas_typecache, typecacheof(/area/rogue/indoors/town
 				/mob/living/carbon/human/species/skeleton/npc/ambush = 20,
 				/mob/living/simple_animal/hostile/retaliate/rogue/wolf = 60,
 				/mob/living/simple_animal/hostile/retaliate/rogue/trollbog = 20,
+				/mob/living/carbon/human/species/npc/deadite = 20,
 				/mob/living/simple_animal/hostile/retaliate/rogue/spider = 40,
 				/mob/living/carbon/human/species/goblin/npc/ambush/cave = 30)
 	first_time_text = "THE TERRORBOG"

--- a/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
+++ b/code/modules/antagonists/roguetown/villain/zombie/zombie.dm
@@ -299,6 +299,33 @@
 	if(world.time > next_idle_sound)
 		zombie.emote("idle")
 		next_idle_sound = world.time + rand(5 SECONDS, 10 SECONDS)
+	
+	if(!zombie.client)
+		try_bite_nearby_person(zombie)
+
+/datum/antagonist/zombie/proc/try_bite_nearby_person(mob/living/carbon/human/zombie)
+	// Check cooldown
+	if(world.time - last_bite < 10 SECONDS)
+		return FALSE
+	// If we’re already biting, chew on the target
+	var/obj/item/grabbing/bite/bite = zombie.get_item_by_slot(SLOT_MOUTH)
+	if(istype(bite))
+		bite.bitelimb(zombie)
+		last_bite = world.time
+		return TRUE
+	// Find a valid target
+	for(var/mob/living/carbon/human/human in view(1, zombie))
+		if(human.stat >= DEAD)
+			continue
+		if(human.mob_biotypes & MOB_UNDEAD)
+			continue
+		if(("undead" in human.faction) || ("zombie" in human.faction))
+			continue
+		// Bite the mob
+		human.onbite(zombie)
+		last_bite = world.time
+		return TRUE
+	return FALSE
 
 /*
 	Check for zombie infection post bite

--- a/code/modules/mob/living/carbon/human/npc/deadite.dm
+++ b/code/modules/mob/living/carbon/human/npc/deadite.dm
@@ -29,8 +29,10 @@
 /mob/living/carbon/human/species/npc/deadite/after_creation()
 	. = ..()
 	src.mind_initialize()
-	src.mind.add_antag_datum(/datum/antagonist/zombie, team = FALSE, admin_panel = TRUE)
+	var/datum/zombie_antag = src.mind.add_antag_datum(/datum/antagonist/zombie, team = FALSE, admin_panel = TRUE)
 	equipOutfit(new /datum/outfit/job/roguetown/deadite)
+
+	GLOB.antagonists -= zombie_antag
 
 /datum/outfit/job/roguetown/deadite/pre_equip(mob/living/carbon/human/H)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

 Adds Deadites to a few areas, for ambushes. Keep in mind those are very simple no-armor Deadite NPCs. Also lets them attempt a bite every 10 seconds + gives deadite NPC mobs a chance to say something before turning, Also makes sure NPC deadites don't clutter the global antag list.

## Why It's Good For The Game

It adds ever so slightly more variety to ambushes in the forest, as the pop is a bit low at the moment you wouldn't see deadites normally otherwise. 
