### PR TITLE
REGIONAL ZYBANTU ACCENTS (& corrections to High Imperial & Zybantu (Now West Zybantu))

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
@@ -37,6 +37,10 @@
 			return strings("welsh_replacement.json", type)
 		if("West Zybantu accent")
 			return strings("arabic_replacement.json", type)
+		if("North Zybantu accent")
+			return strings("turkish_replacement.json", type)
+		if("East Zybantu accent")
+			return strings("indian_replacement.json", type)
 		if("High Imperial accent")
 			return strings("latin_replacement.json", type)
 

--- a/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
+++ b/code/modules/mob/living/carbon/human/species_types/roguetown/roguetown_species.dm
@@ -35,7 +35,7 @@
 			return strings("feline_replacement.json", type)
 		if("Slopes accent")
 			return strings("welsh_replacement.json", type)
-		if("Zybantu accent")
+		if("West Zybantu accent")
 			return strings("arabic_replacement.json", type)
 		if("High Imperial accent")
 			return strings("latin_replacement.json", type)

--- a/modular_hearthstone/code/datums/accents.dm
+++ b/modular_hearthstone/code/datums/accents.dm
@@ -14,8 +14,10 @@ GLOBAL_LIST_INIT(character_accents, list("No accent",
 	"Inzectoid accent",
 	"Feline accent",
 	"Slopes accent",
-    "Zybantu accent",
-    "High Imperial accent"))
+    "West Zybantu accent",
+    "High Imperial accent",
+	"East Zybantu accent",
+	"North Zybantu accent"))
 
 /mob/living/carbon/human
 	var/char_accent = "No accent"

--- a/modular_hearthstone/code/datums/accents.dm
+++ b/modular_hearthstone/code/datums/accents.dm
@@ -15,9 +15,9 @@ GLOBAL_LIST_INIT(character_accents, list("No accent",
 	"Feline accent",
 	"Slopes accent",
     "West Zybantu accent",
-    "High Imperial accent",
+    "North Zybantu accent",
 	"East Zybantu accent",
-	"North Zybantu accent"))
+	"High Imperial accent"))
 
 /mob/living/carbon/human
 	var/char_accent = "No accent"

--- a/strings/arabic_replacement.json
+++ b/strings/arabic_replacement.json
@@ -13,32 +13,31 @@
     "thank you": "jukran",
     "you're welcome": "aafwan",
     "excuse me": "alaafw",
-    "arjuu almaadhira": "I am sorry",
+    "I am sorry": "arjuu almaadhira",
     "good morning": "sabaah alkhayr",
     "good evening": "masaa' alkhayr",
     "good night": "tusbhih aalaah khayr",
-    "what is your name?": "maa ismuk",
+    "what is your name?": "maa ismuk?",
     "how are you": "kayfa haluk",
     "I'm fine": "anaa bihkayr jukran",
     "I am fine": "anaa bikhayr jukran"
   	},
     "start": {
-      "q": "q'"
+		"q": "q'",
+		"k": "q"
     },
     "end": {
       "a": "ah",
       "e": "eh",
-      "o": "oh"
-    },
-    "syllable": {
-		"th": "s",
-  	"s": "ss",
-    "r": "rr",
-    "sh": "j",
-    "j": "jj",
-    "k": "q",
-    "q": "kh",
+      "o": "oh",
+	 "k": "kh",
     "d": "dh",
     "b": "bh"
+    },
+    "syllable": {
+	"th": "s",
+    "r": "rr",
+	"j": "jj"
+    "sh": "jh",
     }
 }

--- a/strings/indian_replacement.json
+++ b/strings/indian_replacement.json
@@ -1,0 +1,21 @@
+{
+    "full": {
+
+    },
+	"multiword": {
+
+  	},
+    "start": {
+    "th": "d"
+    },
+    "end": {
+      "s": "z"
+    },
+    "syllable": {
+     "j": "dzh",
+     "f": "v",
+      "o": "oe",
+      "u": "oo",
+    "ie": "ee"
+    }
+}

--- a/strings/latin_replacement.json
+++ b/strings/latin_replacement.json
@@ -6,7 +6,9 @@
      "actions": "res",
      "action": "res",
      "library": "liberarium",
+		"libraries": "liberaria",
      "book": "liber",
+		"books": "liberi",
      "now": "jam",
      "presently": "jam",
      "and": "et",
@@ -131,8 +133,6 @@
     },
     "syllable": {
         "u": "v",
-        "i": "ee",
-        "c": "ch",
         "w": "v"
     }
 }

--- a/strings/turkish_replacement.json
+++ b/strings/turkish_replacement.json
@@ -1,0 +1,26 @@
+{
+    "full": {
+		"hello ": "merhaba",
+    },
+	"multiword": {
+    "good morning": "gu daynin",
+    "what is your name": "adiniz ne",
+    "thank you": "elinize saglik",
+    "you're welcome": "rica ederim"
+    "
+  	},
+    "start": {
+		"qu": "ku'",
+      "th": "d",
+      "j": "dj",
+      "ch": "tsh"
+    },
+    "end": {
+      "e": "u",
+      "ing": "ink"
+    },
+    "syllable": {
+	"w": "v",
+      "u": "a"
+    }
+}

--- a/strings/turkish_replacement.json
+++ b/strings/turkish_replacement.json
@@ -1,6 +1,6 @@
 {
     "full": {
-		"hello ": "merhaba",
+		"hello ": "merhaba"
     },
 	"multiword": {
     "good morning": "gu daynin",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Renames Zybantu to West Zybantu, adds two new accents in the form of North Zybantu (turk-esque) and East Zybantu (Indian-esque), also tones down syllable correction on High Imperial, and fixes an error with the West Zybantu accent.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

My ambition here is to have a significant correlation between the Humen ancestries and the available accents. Right now there are significantly more ancestries available than accents, which to me makes no sense, considering some of the available accents don't have a correlary location in the Humen ancestry tab (species-specific accents, like Elfish or Aasimar).

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
