### PR TITLE
Grenz accent changes.

### DIFF
--- a/strings/german_replacement.json
+++ b/strings/german_replacement.json
@@ -47,6 +47,7 @@
         "wind": "wind",
         "with": "mit",
         "yes": "ja",
+        "yea": "ja",
         "young": "jung",
         "soldier": "soldat",
         "knight": "ritter",
@@ -83,6 +84,6 @@
 
     },
     "syllable": {
-
+        "w": "v"
     }
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
![image](https://github.com/user-attachments/assets/0dedce58-965b-41a0-9b92-794ad55beddb)
Grenzer accents now swap W's for V's. This includes german full swaps for reference.
Grenzer accents will also now swap Yea for 'Ja'.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This helps tell people you have an accent rather than being a doofus throwing random german words at people.
The Yea change is because I found it kinda dumb that you would swap 'Yes' but not Yea???
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
