### PR TITLE
Removes Wine from Grenzer autoreplacement and replaces it with a Beer autoreplacement.

### DIFF
--- a/strings/german_replacement.json
+++ b/strings/german_replacement.json
@@ -43,7 +43,7 @@
         "ugly": "hässlich",
         "very": "sehr",
         "water": "wasser",
-        "wine": "wein",
+        "beer": "bier",
         "wind": "wind",
         "with": "mit",
         "yes": "ja",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Beer->Bier
Wine was removed because it goes to 'vein' with the W autoreplacement.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why is Beer not autoreplaced?
The Wein one has to go if we're keeping W's swapping else everyone is gonna be confused about you asking for veins.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
