### PR TITLE
Adds Zybean to Desert Riders and the Archivist

### DIFF
--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/desertrider.dm
@@ -91,4 +91,4 @@
 					l_hand = /obj/item/rogueweapon/huntingknife/idagger
 
 	backpack_contents = list(/obj/item/roguekey/mercenary, /obj/item/rogueweapon/huntingknife/idagger/navaja, /obj/item/clothing/neck/roguetown/shalal, /obj/item/clothing/neck/roguetown/mercmedal/zybatine)
-
+	H.grant_language(/datum/language/zybean)

--- a/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
+++ b/code/modules/jobs/job_types/roguetown/yeomen/archivist.dm
@@ -39,7 +39,7 @@
 	shoes = /obj/item/clothing/shoes/roguetown/shortboots
 	belt = /obj/item/storage/belt/rogue/leather/plaquesilver
 	beltl = /obj/item/storage/keyring/archivist
-	beltr = /obj/item/storage/belt/rogue/pouch/coins/mid
+	beltr = /obj/item/storage/belt/rogue/pouch/coins/rich
 	mask = /obj/item/clothing/mask/rogue/spectacles
 
 	if(H.mind)
@@ -61,7 +61,8 @@
 		H.grant_language(/datum/language/orcish)
 		H.grant_language(/datum/language/canilunzt)
 		H.grant_language(/datum/language/grenzelhoftian)
-		H.grant_language(/datum/language/draconic) // All but beast, which is associated with werewolves.
+		H.grant_language(/datum/language/draconic)
+		H.grant_language(/datum/language/zybean) // All but beast, which is associated with Dendor and Werewolves.
 		ADD_TRAIT(H, TRAIT_SEEPRICES, type)
 		ADD_TRAIT(H, TRAIT_INTELLECTUAL, TRAIT_GENERIC)
 		ADD_TRAIT(H, TRAIT_MAGEARMOR, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Read title.

## Why It's Good For The Game

Desert riders get their origin language (they are literally from the Ziggurat) and the Archivist gets the language as well since they are supposed to be the bilingual super-genius.