### PR TITLE
Adjucators no longer get holy magic

### DIFF
--- a/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
+++ b/code/modules/jobs/job_types/roguetown/Inquisition/orthoclasses/psydoniantemplar.dm
@@ -36,10 +36,10 @@
 		H.mind.adjust_skillrank(/datum/skill/misc/climbing, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/athletics, 3, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
-		H.mind.adjust_skillrank(/datum/skill/magic/holy, 2, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/misc/medicine, 1, TRUE)
 		H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
-		H.change_stat("strength", 1)
+		H.change_stat("strength", 2)
+		H.change_stat("constitution", 1)
 		H.change_stat("endurance", 3)
 		
 		ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)
@@ -47,9 +47,6 @@
 		ADD_TRAIT(H, TRAIT_INQUISITION, TRAIT_GENERIC)
 
 		H.dna.species.soundpack_m = new /datum/voicepack/male/knight()
-		var/datum/devotion/C = new /datum/devotion(H, H.patron)
-		C.grant_spells_templar(H)
-		H.verbs += list(/mob/living/carbon/human/proc/devotionreport, /mob/living/carbon/human/proc/clericpray)
 
 
 /datum/outfit/job/roguetown/psydoniantemplar/choose_loadout(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Psydon isn't real and can't hurt you (but his goons certainly are and definitely can)
This removes Adjucator's miracles since psydon isn't even real. I gave them a bit extra stats (1 str and 1 con) to compensate for the removal of their miracles.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Psydon isn't real lorewise so he shouldn't be able to grant you miracles in the first place.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
