### PR TITLE
Estoc is rebalanced to now a two handed sword rather than a greatsword.

### DIFF
--- a/code/game/objects/items/rogueweapons/melee/polearms.dm
+++ b/code/game/objects/items/rogueweapons/melee/polearms.dm
@@ -115,8 +115,7 @@
 	animname = "stab"
 	blade_class = BCLASS_STAB
 	hitsound = list('sound/combat/hits/bladed/genstab (1).ogg', 'sound/combat/hits/bladed/genstab (2).ogg', 'sound/combat/hits/bladed/genstab (3).ogg')
-	reach = 2
-	penfactor = 30
+	penfactor = 35
 	damfactor = 1.2
 	chargetime = 1
 	recovery = 20
@@ -573,10 +572,10 @@
 
 /obj/item/rogueweapon/estoc
 	name = "estoc"
-	desc = "A sword possessed of a quite long and tapered blade that is intended to be thrust between the \
-	gaps in an opponent's armor. The hilt is wrapped tight in black leather."
+	desc = "A thrusting variation of a longsword meant to be used highly effectively against armored opponents with its pointed edge at the cost of terrible slashing performance. Barely usable one-handed."
 	icon_state = "estoc"
 	icon = 'icons/roguetown/weapons/64.dmi'
+	slot_flags = ITEM_SLOT_HIP | ITEM_SLOT_BACK
 	pixel_y = -16
 	pixel_x = -16
 	inhand_x_dimension = 64
@@ -584,24 +583,24 @@
 	force = 12
 	force_wielded = 25
 	possible_item_intents = list(
-		/datum/intent/sword/chop,
+		/datum/intent/sword/chop/awful,
 		/datum/intent/sword/strike,
 	)
 	gripped_intents = list(
 		/datum/intent/sword/thrust/estoc,
 		/datum/intent/sword/lunge,
-		/datum/intent/sword/chop,
+		/datum/intent/sword/chop/awful,
 		/datum/intent/sword/strike,
 	)
 	bigboy = TRUE
 	gripsprite = TRUE
-	wlength = WLENGTH_GREAT
+	wlength = WLENGTH_LONG
 	w_class = WEIGHT_CLASS_BULKY
 	minstr = 8
 	smeltresult = /obj/item/ingot/steel
 	associated_skill = /datum/skill/combat/swords
 	max_blade_int = 300
-	wdefense = 4
+	wdefense = 5 //Since you're supposed to two hand this will be 8 in most scenarios.
 	smelt_bar_num = 2
 	embedding = list("embed_chance" = 0)
 

--- a/code/game/objects/items/rogueweapons/melee/swords.dm
+++ b/code/game/objects/items/rogueweapons/melee/swords.dm
@@ -68,6 +68,11 @@
 /datum/intent/sword/chop/falx
 	penfactor = 40
 
+/datum/intent/sword/chop/awful // This is for pure thrusting swords with very little slashing power as an absolute last resort.
+	name = "cleave"
+	attack_verb = list("awkwardly cleaves", "poorly splits")
+	damfactor = 0.5
+
 //sword objs ฅ^•ﻌ•^ฅ
 
 /obj/item/rogueweapon/sword

--- a/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/wretch.dm
@@ -69,7 +69,6 @@
 	switch(weapon_choice)
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
-			backr = /obj/item/gwstrap
 		if("Mace + Shield")
 			beltr = /obj/item/rogueweapon/mace/steel
 			backr = /obj/item/rogueweapon/shield/tower/metal

--- a/code/modules/jobs/job_types/roguetown/nobility/captain.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/captain.dm
@@ -133,7 +133,6 @@
 			r_hand = /obj/item/rogueweapon/stoneaxe/battle
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/gwstrap
 		if("Bastard Sword & Shield")
 			beltr = /obj/item/rogueweapon/sword/long
 			backl = /obj/item/rogueweapon/shield/tower/metal

--- a/code/modules/jobs/job_types/roguetown/nobility/knight.dm
+++ b/code/modules/jobs/job_types/roguetown/nobility/knight.dm
@@ -122,7 +122,6 @@
 			r_hand = /obj/item/rogueweapon/stoneaxe/battle
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/gwstrap
 	
 
 	neck = /obj/item/clothing/neck/roguetown/gorget
@@ -346,7 +345,6 @@
 
 		if("Estoc")
 			r_hand = /obj/item/rogueweapon/estoc
-			backl = /obj/item/gwstrap
 		
 		if("Sabre + Buckler")
 			r_hand = /obj/item/rogueweapon/sword/sabre

--- a/modular_azurepeak/code/game/objects/items/gwstrap.dm
+++ b/modular_azurepeak/code/game/objects/items/gwstrap.dm
@@ -25,7 +25,7 @@
 	sewrepair = TRUE
 
 /obj/item/gwstrap/attackby(obj/A, mob/living/carbon/user, params)
-	if(istype(A, /obj/item/rogueweapon/spear) || istype(A, /obj/item/rogueweapon/eaglebeak) || istype(A, /obj/item/rogueweapon/halberd) || istype(A, /obj/item/rogueweapon/estoc) || istype(A, /obj/item/rogueweapon/greatsword))
+	if(istype(A, /obj/item/rogueweapon/spear) || istype(A, /obj/item/rogueweapon/eaglebeak) || istype(A, /obj/item/rogueweapon/halberd) || istype(A, /obj/item/rogueweapon/greatsword))
 		if(weps == null)
 			for(var/obj/item/gwstrap/I in user.get_equipped_items(TRUE))
 				to_chat(loc, span_warning("I work the latches of my strap to holster [A]."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Remove greatweapon strap requirement
- Remove reach 2 from lunge, adds 5 pen to it.
- Greatsword length -> Longsword length (can't hit feet with it)
- WDEF 4->5 [7->8 effectively for 80% base parry once two handed.],
- Adds a awful chop for dedicated thrusting swords.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This effectively makes the Estoc a dedicated 2 handed Longsword. You need to two hand it to get any of its actually good intents so you give up the comfort of even a dollar store ass wood shield which has 10 wdef and the ability to block arrows.

But this makes it closer to a proper Estoc than whatever the abomination that it is currently as a screwed up pike Greatsword thing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
