### PR TITLE
Bandit Favor House Cleaning, Readds Hedge Knight, Adds a few options to certain banditos.

### DIFF
--- a/code/modules/cargo/packsrogue/Brigand.dm
+++ b/code/modules/cargo/packsrogue/Brigand.dm
@@ -58,13 +58,6 @@
 	cost = 20
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
-
-/datum/supply_pack/rogue/Brigand/blksteelcuirass
-	name = "Blacksteel Cuirass"
-	cost = 150
-	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate)
-
-
 /datum/supply_pack/rogue/Brigand/Bevor
 	name = "Bevor"
 	cost = 90
@@ -171,3 +164,9 @@
 	name = "Heater Shield"
 	cost = 45
 	contains = list(/obj/item/rogueweapon/shield/heater)
+
+/* Blacksteel is disabled for bandit jobs but this is left here for reference if its ever rebalanced.
+/datum/supply_pack/rogue/Brigand/blksteelcuirass
+	name = "Blacksteel Cuirass"
+	cost = 150
+	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate) */

--- a/code/modules/cargo/packsrogue/Knave.dm
+++ b/code/modules/cargo/packsrogue/Knave.dm
@@ -71,6 +71,11 @@
 	cost = 40
 	contains = list(/obj/item/rogueweapon/huntingknife/idagger/silver/elvish)
 
+/datum/supply_pack/rogue/Knave/smesser
+	name = "Steel Messer"
+	cost = 30
+	contains = list(/obj/item/rogueweapon/sword/messer)
+
 
 /datum/supply_pack/rogue/Knave/steeltossblades
 	name = "Steel Tossblade Belt"

--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -96,10 +96,15 @@
 	cost = 25
 	contains = list(/obj/item/clothing/gloves/roguetown/plate)
 
-/datum/supply_pack/rogue/Brigand/chaingauntlets
+/datum/supply_pack/rogue/Knight/chaingauntlets
 	name = "Steel Chain Gauntlets"
 	cost = 25
 	contains = list(/obj/item/clothing/gloves/roguetown/chain)
+
+/datum/supply_pack/rogue/Knight/chainlegs
+	name = "Chain Chausses"
+	cost = 25
+	contains = list(/obj/item/clothing/under/roguetown/chainlegs)
 
 /datum/supply_pack/rogue/Knight/platechausses
 	name = "Plate Chausses"

--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -17,39 +17,34 @@
 
 /datum/supply_pack/rogue/Knight/wolfhelm
 	name = "Volf Plate Helm"
-	cost = 30
+	cost = 35
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/volfplate)
 
 /datum/supply_pack/rogue/Knight/pigface
 	name = "Pigface Bascinet"
-	cost = 40
+	cost = 70
 	contains = list(/obj/item/clothing/head/roguetown/helmet/bascinet/pigface)
 
 /datum/supply_pack/rogue/Knight/knighthelm
 	name = "Knight's Helmet"
-	cost = 40
+	cost = 70
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/knight)
 
 /datum/supply_pack/rogue/Knight/bhelm
 	name = "Bucket Helm"
-	cost = 40
+	cost = 50
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/bucket)
 
-
-/datum/supply_pack/rogue/Knight/blkstelbuckhelm
-	name = "Blacksteel Bucket Helm"
+/datum/supply_pack/rogue/Knight/fullplate_iron
+	name = "Iron Full plate"
 	cost = 200
-	contains = list(/obj/item/clothing/head/roguetown/helmet/blacksteel/bucket)
+	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full/iron)
+
 
 /datum/supply_pack/rogue/Knight/Fullplate
 	name = "Steel Full plate"
-	cost = 150
+	cost = 300
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full)
-
-/datum/supply_pack/rogue/Knight/blacksteelfullplate
-	name = "Blacksteel Full plate"
-	cost = 250
-	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_full_plate)
 
 /datum/supply_pack/rogue/Knight/hauberk
 	name = "Hauberk"
@@ -58,7 +53,7 @@
 
 /datum/supply_pack/rogue/Knight/Haubergeon
 	name = "Haubergeon"
-	cost = 75
+	cost = 35
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail)
 
 /datum/supply_pack/rogue/Knight/coif/steel
@@ -68,7 +63,7 @@
 
 /datum/supply_pack/rogue/Knight/Bevor
 	name = "Bevor"
-	cost = 35
+	cost = 90
 	contains = list(/obj/item/clothing/neck/roguetown/bevor)
 
 /datum/supply_pack/rogue/Knight/gorget
@@ -86,32 +81,15 @@
 	cost = 25
 	contains = list(/obj/item/clothing/gloves/roguetown/plate)
 
-/datum/supply_pack/rogue/Knight/blkplategaunt
-	name = "Blacksteel Plate Gauntlets"
-	cost = 65
-	contains = list(/obj/item/clothing/gloves/roguetown/blacksteel/plategloves)
-
 /datum/supply_pack/rogue/Knight/platechausses
 	name = "Plate Chausses"
-	cost = 65
+	cost = 100
 	contains = list(/obj/item/clothing/under/roguetown/platelegs)
-
-
-/datum/supply_pack/rogue/Knight/blkplatechausses
-	name = "Blacksteel Plate Chausses"
-	cost = 125
-	contains = list(/obj/item/clothing/under/roguetown/platelegs/blacksteel)
 
 /datum/supply_pack/rogue/Knight/plateboots
 	name = "Plated boots"
 	cost = 45
 	contains = list(/obj/item/clothing/shoes/roguetown/boots/armor)
-
-/datum/supply_pack/rogue/Knight/blkplateboots
-	name = "Blacksteel Plated boots"
-	cost = 95
-	contains = list(/obj/item/clothing/shoes/roguetown/boots/blacksteel/plateboots)
-
 
 /datum/supply_pack/rogue/Knight/bsword
 	name = "Bastard Sword"
@@ -125,12 +103,12 @@
 
 /datum/supply_pack/rogue/Knight/greatsword
 	name = "Greatsword"
-	cost = 60
+	cost = 80
 	contains = list(/obj/item/rogueweapon/greatsword)
 
 /datum/supply_pack/rogue/Knight/Zweihandersword
 	name = "Zweihander"
-	cost = 30
+	cost = 70
 	contains = list(/obj/item/rogueweapon/greatsword/zwei)
 
 
@@ -138,3 +116,29 @@
 	name = "Kite Shield"
 	cost = 20
 	contains = list(/obj/item/rogueweapon/shield/tower/metal)
+
+/* Blacksteel is disabled for bandit jobs but this is left here for reference if its ever rebalanced.
+/datum/supply_pack/rogue/Knight/blacksteelfullplate
+	name = "Blacksteel Full plate"
+	cost = 250
+	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_full_plate)
+
+/datum/supply_pack/rogue/Knight/blkstelbuckhelm
+	name = "Blacksteel Bucket Helm"
+	cost = 200
+	contains = list(/obj/item/clothing/head/roguetown/helmet/blacksteel/bucket)
+
+/datum/supply_pack/rogue/Knight/blkplateboots
+	name = "Blacksteel Plated boots"
+	cost = 95
+	contains = list(/obj/item/clothing/shoes/roguetown/boots/blacksteel/plateboots)
+
+/datum/supply_pack/rogue/Knight/blkplatechausses
+	name = "Blacksteel Plate Chausses"
+	cost = 125
+	contains = list(/obj/item/clothing/under/roguetown/platelegs/blacksteel)
+
+/datum/supply_pack/rogue/Knight/blkplategaunt
+	name = "Blacksteel Plate Gauntlets"
+	cost = 65
+	contains = list(/obj/item/clothing/gloves/roguetown/blacksteel/plategloves) */

--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -56,7 +56,7 @@
 	cost = 20
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
-/datum/supply_pack/rogue/Knight/hauberk
+/datum/supply_pack/rogue/Knight/fluted_hauberk
 	name = "Fluted Hauberk"
 	cost = 100
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/fluted)

--- a/code/modules/cargo/packsrogue/Knight.dm
+++ b/code/modules/cargo/packsrogue/Knight.dm
@@ -32,8 +32,13 @@
 
 /datum/supply_pack/rogue/Knight/bhelm
 	name = "Bucket Helm"
-	cost = 50
+	cost = 70
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/bucket)
+
+/datum/supply_pack/rogue/Knight/steelcuirass
+	name = "Steel Cuirass"
+	cost = 60
+	contains =  list(/obj/item/clothing/suit/roguetown/armor/plate/half)
 
 /datum/supply_pack/rogue/Knight/fullplate_iron
 	name = "Iron Full plate"
@@ -45,6 +50,16 @@
 	name = "Steel Full plate"
 	cost = 300
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/full)
+
+/datum/supply_pack/rogue/Knight/hgambeson
+	name = "Heavy Gambeson"
+	cost = 20
+	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
+
+/datum/supply_pack/rogue/Knight/hauberk
+	name = "Fluted Hauberk"
+	cost = 100
+	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk/fluted)
 
 /datum/supply_pack/rogue/Knight/hauberk
 	name = "Hauberk"
@@ -80,6 +95,11 @@
 	name = "Plate Gauntlets"
 	cost = 25
 	contains = list(/obj/item/clothing/gloves/roguetown/plate)
+
+/datum/supply_pack/rogue/Brigand/chaingauntlets
+	name = "Steel Chain Gauntlets"
+	cost = 25
+	contains = list(/obj/item/clothing/gloves/roguetown/chain)
 
 /datum/supply_pack/rogue/Knight/platechausses
 	name = "Plate Chausses"

--- a/code/modules/cargo/packsrogue/Sellsword.dm
+++ b/code/modules/cargo/packsrogue/Sellsword.dm
@@ -6,8 +6,8 @@
 
 
 /datum/supply_pack/rogue/Sellsword/dridersword
-	name = "Old Zybantine package..."
-	cost = 10
+	name = "Shamshir"
+	cost = 30
 	contains = list(/obj/item/rogueweapon/sword/long/rider)
 
 
@@ -39,44 +39,44 @@
 
 /datum/supply_pack/rogue/Sellsword/chainlegs
 	name = "Chain Chausses"
-	cost = 20
+	cost = 25
 	contains = list(/obj/item/clothing/under/roguetown/chainlegs)
 
 /datum/supply_pack/rogue/Sellsword/bracers
 	name = "Steel Bracers"
-	cost = 10
+	cost = 25
 	contains = list(/obj/item/clothing/wrists/roguetown/bracers)
 
 
 /datum/supply_pack/rogue/Sellsword/chaingauntlets
 	name = "Steel Chain Gauntlets"
-	cost = 10
+	cost = 25
 	contains = list(/obj/item/clothing/gloves/roguetown/chain)
 
 /datum/supply_pack/rogue/Sellsword/boots
 	name = "Steel Boots"
-	cost = 10
+	cost = 25
 	contains = list(/obj/item/clothing/shoes/roguetown/boots/armor)
 
 
 /datum/supply_pack/rogue/Sellsword/hauberk
 	name = "Hauberk"
-	cost = 30
+	cost = 50
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail/hauberk)
 
 /datum/supply_pack/rogue/Sellsword/Haubergeon
 	name = "Haubergeon"
-	cost = 20
+	cost = 35
 	contains = list(/obj/item/clothing/suit/roguetown/armor/chainmail)
 
 /datum/supply_pack/rogue/Sellsword/steelcuirass
 	name = "Steel Cuirass"
-	cost = 20
+	cost = 60
 	contains =  list(/obj/item/clothing/suit/roguetown/armor/plate/half)
 
 /datum/supply_pack/rogue/Sellsword/scalemail
 	name = "Scalemail"
-	cost = 20
+	cost = 100
 	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/scale)
 
 /datum/supply_pack/rogue/Sellsword/hgambeson
@@ -85,15 +85,9 @@
 	contains = list(/obj/item/clothing/suit/roguetown/armor/gambeson/heavy)
 
 
-/datum/supply_pack/rogue/Sellsword/steelcuirass
-	name = "Blacksteel Cuirass"
-	cost = 150
-	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate)
-
-
 /datum/supply_pack/rogue/Sellsword/Bevor
 	name = "Bevor"
-	cost = 20
+	cost = 90
 	contains = list(/obj/item/clothing/neck/roguetown/bevor)
 
 
@@ -105,23 +99,23 @@
 
 /datum/supply_pack/rogue/Sellsword/kettle
 	name = "Kettle Helmet"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/clothing/head/roguetown/helmet/kettle)
 
 /datum/supply_pack/rogue/Sellsword/sallet
 	name = "Sallet"
-	cost = 35
+	cost = 25
 	contains = list(/obj/item/clothing/head/roguetown/helmet/sallet)
 
 
 /datum/supply_pack/rogue/Sellsword/visoredsallet
 	name = "Visored Sallet"
-	cost = 65
+	cost = 85
 	contains = list(/obj/item/clothing/head/roguetown/helmet/sallet/visored)
 
 /datum/supply_pack/rogue/Sellsword/wolfhelm
 	name = "Volf Plate Helm"
-	cost = 50
+	cost = 35
 	contains = list(/obj/item/clothing/head/roguetown/helmet/heavy/volfplate)
 
 
@@ -143,12 +137,12 @@
 
 /datum/supply_pack/rogue/Sellsword/billhook
 	name = "Billhook"
-	cost = 10
+	cost = 100
 	contains = list(/obj/item/rogueweapon/spear/billhook)
 
 /datum/supply_pack/rogue/Sellsword/halberd
 	name = "Halberd"
-	cost = 10
+	cost = 100
 	contains = list(/obj/item/rogueweapon/halberd)
 
 /datum/supply_pack/rogue/Sellsword/spear
@@ -158,17 +152,17 @@
 
 /datum/supply_pack/rogue/Sellsword/bardiche
 	name = "Bardiche"
-	cost = 10
+	cost = 75
 	contains = list(/obj/item/rogueweapon/halberd/bardiche)
 
 /datum/supply_pack/rogue/Sellsword/ebeak
 	name = "Eagle's Beak"
-	cost = 20
+	cost = 200
 	contains = list(/obj/item/rogueweapon/eaglebeak)
 
 /datum/supply_pack/rogue/Sellsword/Lucerne
 	name = "Lucerne"
-	cost = 20
+	cost = 150
 	contains = list(/obj/item/rogueweapon/eaglebeak/lucerne)
 
 /datum/supply_pack/rogue/Sellsword/bolts
@@ -181,3 +175,9 @@
 	name = "Crossbow"
 	cost = 20
 	contains = list(/obj/item/gun/ballistic/revolver/grenadelauncher/crossbow)
+
+/* Blacksteel is disabled for bandit jobs but this is left here for reference if its ever rebalanced.
+/datum/supply_pack/rogue/Brigand/blksteelcuirass
+	name = "Blacksteel Cuirass"
+	cost = 150
+	contains = list(/obj/item/clothing/suit/roguetown/armor/plate/blacksteel_half_plate) */

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -5,12 +5,12 @@
 	allowed_races = RACES_ALL_KINDS
 	outfit = /datum/outfit/job/roguetown/bandit/hedgeknight
 	category_tags = list(CTAG_BANDIT)
-	maximum_possible_slots = 1 // You're the 'Big' guy of the Bandit Camp. Could replace Iconoclast as the bandit leader eventually.
+	maximum_possible_slots = 1 // You're the 'Big' guy of the Bandit Camp. Could replace Iconoclast as the Bandit leader eventually.
 	cmode_music = 'sound/music/combat_bandit.ogg'
 
 /datum/outfit/job/roguetown/bandit/hedgeknight/pre_equip(mob/living/carbon/human/H)
 	..()
-	head = /obj/item/clothing/head/roguetown/helmet/heavy
+	head = /obj/item/clothing/head/roguetown/helmet/kettle
 	gloves = /obj/item/clothing/gloves/roguetown/leather
 	pants = /obj/item/clothing/under/roguetown/trou/leather
 	cloak = /obj/item/clothing/cloak/tabard/blkknight
@@ -42,6 +42,6 @@
 	H.change_stat("strength", 2)
 	H.change_stat("endurance", 2)
 	H.change_stat("constitution", 2) //dark souls 3 dual greatshield moment
-	H.change_stat("intelligence", -4) // This is mainly to absolutely fuck up your ability to learn ANY skill and make you super susceptible to being feinted.
+	H.change_stat("intelligence", -3) // This is mainly to absolutely fuck up your ability to learn ANY skill and make you super susceptible to being feinted. Tough muscle. Make your teammates use the thinking skills for you.
 	H.change_stat("speed", 1)
 	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -1,0 +1,47 @@
+/datum/advclass/hedgeknight //Knight class, good stats and equipment but your int absolutely sucks so good luck learning anything and everyone will freak out at you.
+	name = "Hedge Cataphract"
+	tutorial = "A warrior fallen from grace, your tarnished armor sits upon your shoulders as a heavy reminder of the life you've lost. Take back what is rightfully yours."
+	allowed_sexes = list(MALE, FEMALE)
+	allowed_races = RACES_ALL_KINDS
+	outfit = /datum/outfit/job/roguetown/bandit/hedgeknight
+	category_tags = list(CTAG_BANDIT)
+	maximum_possible_slots = 1 // You're the 'Big' guy of the Bandit Camp. Could replace Iconoclast as the bandit leader eventually.
+	cmode_music = 'sound/music/combat_bandit.ogg'
+
+/datum/outfit/job/roguetown/bandit/hedgeknight/pre_equip(mob/living/carbon/human/H)
+	..()
+	head = /obj/item/clothing/head/roguetown/helmet/heavy
+	gloves = /obj/item/clothing/gloves/roguetown/leather
+	pants = /obj/item/clothing/under/roguetown/trou/leather
+	cloak = /obj/item/clothing/cloak/tabard/blkknight
+	neck = /obj/item/clothing/neck/roguetown/gorget
+	shirt = /obj/item/clothing/suit/roguetown/armor/gambeson
+	armor = /obj/item/clothing/suit/roguetown/armor/brigandine/light
+	wrists = /obj/item/clothing/wrists/roguetown/bracers/leather
+	shoes = /obj/item/clothing/shoes/roguetown/boots
+	belt = /obj/item/storage/belt/rogue/leather
+	beltr = /obj/item/rogueweapon/sword/long
+	backr = /obj/item/storage/backpack/rogue/satchel/black
+	id = /obj/item/mattcoin
+	backpack_contents = list(
+					/obj/item/rogueweapon/huntingknife/idagger = 1,
+					/obj/item/flashlight/flare/torch = 1,
+					)
+	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/swimming, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/climbing, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/reading, 3, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/misc/riding, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/craft/cooking, 1, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/labor/butchering, 1, TRUE)
+	H.change_stat("strength", 2)
+	H.change_stat("endurance", 2)
+	H.change_stat("constitution", 2) //dark souls 3 dual greatshield moment
+	H.change_stat("intelligence", -4) // This is mainly to absolutely fuck up your ability to learn ANY skill and make you super susceptible to being feinted.
+	H.change_stat("speed", 1)
+	ADD_TRAIT(H, TRAIT_HEAVYARMOR, TRAIT_GENERIC)

--- a/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
+++ b/code/modules/jobs/job_types/roguetown/adventurer/types/antag/hedgeknight.dm
@@ -29,7 +29,7 @@
 					)
 	H.mind.adjust_skillrank(/datum/skill/combat/swords, 4, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/knives, 3, TRUE)
-	H.mind.adjust_skillrank(/datum/skill/combat/shields, 2, TRUE)
+	H.mind.adjust_skillrank(/datum/skill/combat/shields, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/wrestling, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/combat/unarmed, 3, TRUE)
 	H.mind.adjust_skillrank(/datum/skill/misc/athletics, 4, TRUE)

--- a/code/modules/roguetown/roguemachine/hoardmaster.dm
+++ b/code/modules/roguetown/roguemachine/hoardmaster.dm
@@ -94,7 +94,7 @@
 			unlocked_cats+="Sellsword"
 		if("Sawbones")
 			unlocked_cats+="Sawbones"
-		if("Hedge Knight")
+		if("Hedge Cataphract")
 			unlocked_cats+="Knight"
 		if("Rogue Mage")
 			unlocked_cats+="Mage"

--- a/lyndvhar.dme
+++ b/lyndvhar.dme
@@ -1294,6 +1294,7 @@
 #include "code\modules\jobs\job_types\roguetown\adventurer\wretch.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\_advclass.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\brigand.dm"
+#include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\hedgeknight.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\Iconoclast.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\knave.dm"
 #include "code\modules\jobs\job_types\roguetown\adventurer\types\antag\sawbones.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
First off the most important thing here is I did bandit housecleaning for Sellsword which had a ton of stuff be cheaper because Bowl didn't touch it. This also adds a few options for a few of the banditos in terms of weaponry alongside entirely disabling Blacksteel for them to buy.

This also readds Hedge Knight as a job for Bandits. There's only one and they're the main 'fighty' guy. They have great skills, heavy armor training, and statlines for combat in comparison to most but their intelligence is *absolutely* trash. Here is their spawn loadout and stats with virtuous. They are limited to 1. 
Their gear options range from medium to heavy armor. Its very expensive for them to actually get money since they have no utility skills compared to even the other combat jobs and their gear is super expensive. This means you either run dungeons or strongarm it out of people.
![image](https://github.com/user-attachments/assets/2e612a59-5394-49dc-906d-12681c008bf8)
![image](https://github.com/user-attachments/assets/26ab04e4-0dbb-42bf-b64a-9596118534fb)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bandito favor was all over the place and unifying them is good.
Hedge Knights are cool. They're also stupid, really, really stupid. Really. Stupid. For Bandit variety.
Removing Blacksteel is important because otherwise you can infinitely farm it which is just plain silly.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
