### PR TITLE
Statpack balancjak

### DIFF
--- a/modular_azurepeak/statpacks/agile.dm
+++ b/modular_azurepeak/statpacks/agile.dm
@@ -2,7 +2,7 @@
 /datum/statpack/agile/swift
 	name = "Swift"
 	desc = "With the wind in your hair and trouble at your back, your speed has oft been your salvation."
-	stat_array = list(STAT_STRENGTH = -1, STAT_CONSTITUTION = -2, STAT_ENDURANCE = 1, STAT_SPEED = 3)
+	stat_array = list(STAT_STRENGTH = -1, STAT_PERCEPTION = -2, STAT_CONSTITUTION = -2, STAT_ENDURANCE = 1, STAT_SPEED = 3)
 
 /datum/statpack/agile/quickwitted
 	name = "Quick-Witted"

--- a/modular_azurepeak/statpacks/physical.dm
+++ b/modular_azurepeak/statpacks/physical.dm
@@ -8,12 +8,12 @@
 /datum/statpack/physical/hulking
 	name = "Hulking"
 	desc = "Hard labor has honed you into a lumbering mass of sinew - a valuable trait in a world where might makes right."
-	stat_array = list(STAT_STRENGTH = 4, STAT_INTELLIGENCE = -2, STAT_CONSTITUTION = 1, STAT_SPEED = -2, STAT_ENDURANCE = -1)
+	stat_array = list(STAT_STRENGTH = 4, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -2, STAT_CONSTITUTION = 1, STAT_SPEED = -2, STAT_ENDURANCE = 1)
 
 /datum/statpack/physical/muscular
 	name = "Muscular"
 	desc = "Tall and imposing, yet deceptively fast for your size - your opponents dread the thought of being within arms reach of you."
-	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -1, STAT_CONSTITUTION = 2)
+	stat_array = list(STAT_STRENGTH = 2, STAT_PERCEPTION = -1, STAT_INTELLIGENCE = -2, STAT_CONSTITUTION = 2)
 
 /datum/statpack/physical/tactician
 	name = "Tactician"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Bowl likes saying balancejak so I MJP claim balancjak.
Anyways this does some touches to certain statpacks.

- Swift now removes 2 perception
- Hulking removes a perception and gives you an endurance rather than removing one.
- Muscular drops an int on you.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Swift removes perception from you to balance out the insane gain that is 3 speed. Losing 2 con isn't much of a downside in my experience with the job since 90% of combat jobs (and honestly noncombat jobs in general should probably always swift) gain 1-2 con anyway and I've been one click delimbed with 15 con several times. Removing 2 per means its harder for them to hit gaps in armored opponents if you want to speedmaxx.

Hulking sucks. There's no way to get around it. Losing an endurance and 2 speed is just brutal since anyone with above average (12+) speed will dance around you if you use anything heavier than a regular ass sword and other strength builds can usually just staminabreak you since your endurance sucks poopoo. I considered making it only give 3 str and drop 1 speed but that felt lazy so instead I made it give you an endurance so once you do catch literally anyone you don't get clowned out because you ran out of breath before them in the grapple fight and dropped the perception by one.

Muscular drops another int to make the tradeoffs a bit more apparent. I felt like its way too well rounded right now.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
