### PR TITLE
Fix: Load whitelist from correct file

### DIFF
--- a/code/modules/admin/whitelist.dm
+++ b/code/modules/admin/whitelist.dm
@@ -1,7 +1,7 @@
 #ifdef TESTSERVER
 	#define WHITELISTFILE	"[global.config.directory]/roguetown/wl_test.txt"
 #else
-	#define WHITELISTFILE	"[global.config.directory]/roguetown/wl_mat.txt"
+	#define WHITELISTFILE	"[global.config.directory]/whitelist.txt"
 #endif
 
 GLOBAL_LIST_EMPTY(whitelist)


### PR DESCRIPTION
## About The Pull Request
Actually use ~/config/whitelist.txt as config.txt says, instead of the nowhere-mentioned ~/config/roguetown/wl_mat.txt
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes Whitelist System
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
